### PR TITLE
Commit add images

### DIFF
--- a/src/components/CommitModal.tsx
+++ b/src/components/CommitModal.tsx
@@ -62,6 +62,39 @@ export default function CommitModal({
 
     if (!open || !draft) return null;
 
+    async function compressImage(file: File): Promise<File> {
+        const img = new Image();
+        const url = URL.createObjectURL(file);
+
+        await new Promise((resolve, reject) => {
+            img.onload = resolve;
+            img.onerror = reject;
+            img.src = url;
+        });
+
+        const maxWidth = 1280; // 横幅制限
+        const scale = Math.min(1, maxWidth / img.width);
+
+        const canvas = document.createElement("canvas");
+        canvas.width = img.width * scale;
+        canvas.height = img.height * scale;
+
+        const ctx = canvas.getContext("2d");
+        if (!ctx) throw new Error("Canvas not supported");
+
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+        const blob: Blob = await new Promise((resolve) =>
+            canvas.toBlob((b) => resolve(b!), "image/jpeg", 0.8) // 画質80%
+        );
+
+        URL.revokeObjectURL(url);
+
+        return new File([blob], file.name, {
+            type: "image/jpeg",
+        });
+    }
+
     return (
         <div
             role="dialog"
@@ -124,7 +157,7 @@ export default function CommitModal({
                     <input
                         type="file"
                         accept="image/*"
-                        onChange={(e) => {
+                        onChange={async (e) => {
                             const file = e.target.files?.[0];
                             if (!file) return;
 
@@ -133,10 +166,7 @@ export default function CommitModal({
                                 return;
                             }
 
-                            if (file.size > 5 * 1024 * 1024) {
-                                alert("5MB以下の画像を選択してください");
-                                return;
-                            }
+                            const compressed = await compressImage(file);
 
                             if (draft.image?.previewUrl) {
                                 URL.revokeObjectURL(draft.image.previewUrl);
@@ -145,11 +175,11 @@ export default function CommitModal({
                             onChange({
                                 ...draft,
                                 image: {
-                                    name: file.name,
-                                    type: file.type,
-                                    size: file.size,
-                                    file,
-                                    previewUrl: URL.createObjectURL(file),
+                                    name: compressed.name,
+                                    type: compressed.type,
+                                    size: compressed.size,
+                                    file: compressed,
+                                    previewUrl: URL.createObjectURL(compressed),
                                 },
                             });
 

--- a/src/components/CommitModal.tsx
+++ b/src/components/CommitModal.tsx
@@ -1,5 +1,13 @@
 import React, { useMemo, useState } from "react";
 
+export type DraftCommitImage = {
+    name: string;
+    type: string;
+    size: number;
+    file: File;
+    previewUrl: string;
+};
+
 export type DraftCommit = {
     projectId: string;
     projectName: string;
@@ -7,11 +15,13 @@ export type DraftCommit = {
     endedAt: number;
     note: string;
 
-  // 表示用（App側で計算して渡す）
-  commitNumber: number;      // 何回目
-  todayTotalMs: number;      // 今日累計
-  projectTotalMs: number;    // プロジェクト累計
-  recentNotes: string[];     // 過去メモ（直近）
+    // 表示用（App側で計算して渡す）
+    commitNumber: number;      // 何回目
+    todayTotalMs: number;      // 今日累計
+    projectTotalMs: number;    // プロジェクト累計
+    recentNotes: string[];     // 過去メモ（直近）
+
+    image?: DraftCommitImage | null;
 };
 
 function pad2(n: number) {
@@ -43,122 +53,206 @@ export default function CommitModal({
     onSaveAndContinue,
     onCancel,
 }: Props) {
-const [expanded, setExpanded] = useState(false);
+    const [expanded, setExpanded] = useState(false);
 
-const durationMs = useMemo(() => {
-    if (!draft) return 0;
-    return draft.endedAt - draft.startedAt;
-}, [draft]);
+    const durationMs = useMemo(() => {
+        if (!draft) return 0;
+        return draft.endedAt - draft.startedAt;
+    }, [draft]);
 
-if (!open || !draft) return null;
+    if (!open || !draft) return null;
 
-return (
-    <div
-    role="dialog"
-    aria-modal="true"
-    style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.45)",
-        display: "grid",
-        placeItems: "center",
-        padding: 16,
-        zIndex: 50,
-    }}
-    onMouseDown={(e) => {
-        // 背景クリックで閉じる（誤爆嫌なら消してOK）
-        if (e.target === e.currentTarget) onCancel();
-    }}
-    >
-    <div
-        style={{
-        width: "min(760px, 100%)",
-        background: "white",
-        borderRadius: 14,
-        padding: 16,
-        border: "1px solid #ddd",
-        }}
-    >
-        <div style={{ display: "flex", gap: 12, alignItems: "baseline" }}>
-        <h2 style={{ margin: 0, fontSize: 18 }}>作業コミット</h2>
-        <div style={{ color: "#666", fontSize: 12 }}>
-            {draft.projectName} / #{draft.commitNumber}
-        </div>
-        </div>
-
-        <div style={{ marginTop: 12, display: "grid", gap: 8 }}>
-        <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-            <Stat label="今回" value={formatMs(durationMs)} />
-            <Stat label="今日累計" value={formatMs(draft.todayTotalMs)} />
-            <Stat label="累計" value={formatMs(draft.projectTotalMs)} />
-        </div>
-
-        <div style={{ fontSize: 12, color: "#666" }}>
-            {new Date(draft.startedAt).toLocaleString()} → {new Date(draft.endedAt).toLocaleString()}
-        </div>
-
-        <label style={{ display: "block", fontSize: 12, color: "#555" }}>
-            今日のまとめメモ
-        </label>
-        <textarea
-            value={draft.note}
-            onChange={(e) => onChange({ ...draft, note: e.target.value })}
-            rows={4}
-            placeholder="例：線画の修正 / 目の形を調整 / 背景ラフ"
-            style={{ width: "100%", padding: 10, borderRadius: 10, border: "1px solid #ddd" }}
-        />
-
-        <button
-            type="button"
-            onClick={() => setExpanded((v) => !v)}
-            style={{ width: "fit-content", padding: "6px 10px", borderRadius: 10 }}
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            style={{
+                position: "fixed",
+                inset: 0,
+                background: "rgba(0,0,0,0.45)",
+                display: "grid",
+                placeItems: "center",
+                padding: 16,
+                zIndex: 50,
+            }}
+            onMouseDown={(e) => {
+                // 背景クリックで閉じる（誤爆嫌なら消してOK）
+                if (e.target === e.currentTarget) onCancel();
+            }}
         >
-            {expanded ? "過去メモを隠す" : "過去メモを見る"}
-        </button>
-
-        {expanded && (
-            <div style={{ border: "1px solid #eee", borderRadius: 10, padding: 10 }}>
-            {draft.recentNotes.length === 0 ? (
-                <div style={{ color: "#888", fontSize: 12 }}>まだメモがありません</div>
-            ) : (
-                <ul style={{ margin: 0, paddingLeft: 18 }}>
-                {draft.recentNotes.map((n, i) => (
-                    <li key={i} style={{ marginBottom: 6, whiteSpace: "pre-wrap" }}>
-                    {n}
-                    </li>
-                ))}
-                </ul>
-            )}
-            </div>
-        )}
-        </div>
-
-        <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
-        <button onClick={onCancel} style={{ padding: "10px 14px", borderRadius: 10 }}>
-            キャンセル
-        </button>
-        <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
-            <button onClick={onSave} style={{ padding: "10px 14px", borderRadius: 10 }}>
-            保存して終了
-            </button>
-            <button
-            onClick={onSaveAndContinue}
-            style={{ padding: "10px 14px", borderRadius: 10 }}
+            <div
+                style={{
+                    width: "min(760px, 100%)",
+                    background: "white",
+                    borderRadius: 14,
+                    padding: 16,
+                    border: "1px solid #ddd",
+                }}
             >
-            保存して続ける
-            </button>
+                <div style={{ display: "flex", gap: 12, alignItems: "baseline" }}>
+                    <h2 style={{ margin: 0, fontSize: 18 }}>作業コミット</h2>
+                    <div style={{ color: "#666", fontSize: 12 }}>
+                        {draft.projectName} / #{draft.commitNumber}
+                    </div>
+                </div>
+
+                <div style={{ marginTop: 12, display: "grid", gap: 8 }}>
+                    <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+                        <Stat label="今回" value={formatMs(durationMs)} />
+                        <Stat label="今日累計" value={formatMs(draft.todayTotalMs)} />
+                        <Stat label="累計" value={formatMs(draft.projectTotalMs)} />
+                    </div>
+
+                    <div style={{ fontSize: 12, color: "#666" }}>
+                        {new Date(draft.startedAt).toLocaleString()} → {new Date(draft.endedAt).toLocaleString()}
+                    </div>
+
+                    <label style={{ display: "block", fontSize: 12, color: "#555" }}>
+                        今日のまとめメモ
+                    </label>
+                    <textarea
+                        value={draft.note}
+                        onChange={(e) => onChange({ ...draft, note: e.target.value })}
+                        rows={4}
+                        placeholder="例：線画の修正 / 目の形を調整 / 背景ラフ"
+                        style={{ width: "100%", padding: 10, borderRadius: 10, border: "1px solid #ddd" }}
+                    />
+
+                    <label style={{ display: "block", fontSize: 12, color: "#555" }}>
+                        進捗画像
+                    </label>
+                    <input
+                        type="file"
+                        accept="image/*"
+                        onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (!file) return;
+
+                            if (!file.type.startsWith("image/")) {
+                                alert("画像ファイルを選択してください");
+                                return;
+                            }
+
+                            if (file.size > 5 * 1024 * 1024) {
+                                alert("5MB以下の画像を選択してください");
+                                return;
+                            }
+
+                            if (draft.image?.previewUrl) {
+                                URL.revokeObjectURL(draft.image.previewUrl);
+                            }
+
+                            onChange({
+                                ...draft,
+                                image: {
+                                    name: file.name,
+                                    type: file.type,
+                                    size: file.size,
+                                    file,
+                                    previewUrl: URL.createObjectURL(file),
+                                },
+                            });
+
+                            e.currentTarget.value = "";
+                        }}
+                    />
+
+                    {draft.image && (
+                        <div
+                            style={{
+                                marginTop: 10,
+                                border: "1px solid #eee",
+                                borderRadius: 10,
+                                padding: 10,
+                                width: "fit-content",
+                            }}
+                        >
+                            <img
+                                src={draft.image.previewUrl}
+                                alt={draft.image.name}
+                                style={{
+                                    width: 180,
+                                    height: 180,
+                                    objectFit: "cover",
+                                    borderRadius: 8,
+                                    display: "block",
+                                }}
+                            />
+
+                            <div style={{ marginTop: 8, fontSize: 12, color: "#666" }}>
+                                {draft.image.name}
+                            </div>
+
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    if (draft.image?.previewUrl) {
+                                        URL.revokeObjectURL(draft.image.previewUrl);
+                                    }
+
+                                    onChange({
+                                        ...draft,
+                                        image: null,
+                                    });
+                                }}
+                                style={{ marginTop: 8, padding: "6px 10px", borderRadius: 10 }}
+                            >
+                                画像を外す
+                            </button>
+                        </div>
+                    )}
+
+                    <button
+                        type="button"
+                        onClick={() => setExpanded((v) => !v)}
+                        style={{ width: "fit-content", padding: "6px 10px", borderRadius: 10 }}
+                    >
+                        {expanded ? "過去メモを隠す" : "過去メモを見る"}
+                    </button>
+
+                    {expanded && (
+                        <div style={{ border: "1px solid #eee", borderRadius: 10, padding: 10 }}>
+                            {draft.recentNotes.length === 0 ? (
+                                <div style={{ color: "#888", fontSize: 12 }}>まだメモがありません</div>
+                            ) : (
+                                <ul style={{ margin: 0, paddingLeft: 18 }}>
+                                    {draft.recentNotes.map((n, i) => (
+                                        <li key={i} style={{ marginBottom: 6, whiteSpace: "pre-wrap" }}>
+                                            {n}
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+                    )}
+                </div>
+
+                <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
+                    <button onClick={onCancel} style={{ padding: "10px 14px", borderRadius: 10 }}>
+                        キャンセル
+                    </button>
+                    <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
+                        <button onClick={onSave} style={{ padding: "10px 14px", borderRadius: 10 }}>
+                            保存して終了
+                        </button>
+                        <button
+                            onClick={onSaveAndContinue}
+                            style={{ padding: "10px 14px", borderRadius: 10 }}
+                        >
+                            保存して続ける
+                        </button>
+                    </div>
+                </div>
+            </div>
         </div>
-        </div>
-    </div>
-    </div>
-  );
+    );
 }
 
 function Stat({ label, value }: { label: string; value: string }) {
-  return (
-    <div style={{ border: "1px solid #eee", borderRadius: 10, padding: "8px 10px", minWidth: 120 }}>
-      <div style={{ fontSize: 11, color: "#666" }}>{label}</div>
-      <div style={{ fontSize: 18, fontVariantNumeric: "tabular-nums" }}>{value}</div>
-    </div>
-  );
+    return (
+        <div style={{ border: "1px solid #eee", borderRadius: 10, padding: "8px 10px", minWidth: 120 }}>
+            <div style={{ fontSize: 11, color: "#666" }}>{label}</div>
+            <div style={{ fontSize: 18, fontVariantNumeric: "tabular-nums" }}>{value}</div>
+        </div>
+    );
 }

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -36,13 +36,21 @@ export type WorkSession = {
     pausedAt?: number;
 };
 
+export type CommitImage = {
+    name: string;
+    type: string;
+    size: number;
+    blob: Blob;
+};
+
 export type Commit = {
     id: string;
-    projectId: ProjectId;
+    projectId: string;
     startedAt: number;
     endedAt: number;
     durationMs: number;
-    note: string;
+    note?: string;
+    image?: CommitImage | null;
 };
 
 // 日付セルに置く個人メモ

--- a/src/pages/CommitDetailPage.tsx
+++ b/src/pages/CommitDetailPage.tsx
@@ -21,6 +21,7 @@ export default function CommitDetailPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [commitsAll, setCommitsAll] = useState<Commit[]>([]);
   const [loading, setLoading] = useState(true);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -57,6 +58,20 @@ export default function CommitDetailPage() {
     if (!projectId || !commitId) return null;
     return commitsAll.find((c) => c.id === commitId && c.projectId === projectId) ?? null;
   }, [commitsAll, projectId, commitId]);
+
+  useEffect(() => {
+      if (!commit?.image?.blob) {
+          setImageUrl(null);
+          return;
+      }
+
+      const url = URL.createObjectURL(commit.image.blob);
+      setImageUrl(url);
+
+      return () => {
+          URL.revokeObjectURL(url);
+      };
+  }, [commit]);
 
   if (!projectId || !commitId) {
     return (
@@ -120,7 +135,31 @@ export default function CommitDetailPage() {
             <div style={{ color: "#999" }}>（メモなし）</div>
           )}
         </div>
+        {commit.image && imageUrl && (
+        <div style={{ marginTop: 16 }}>
+            <div style={{ fontSize: 12, color: "#555", marginBottom: 6 }}>添付画像</div>
 
+            <a href={imageUrl} target="_blank" rel="noreferrer">
+                <img
+                    src={imageUrl}
+                    alt={commit.image.name}
+                    style={{
+                        width: "100%",
+                        maxWidth: 420,
+                        height: "auto",
+                        borderRadius: 10,
+                        border: "1px solid #ddd",
+                        display: "block",
+                        cursor: "zoom-in",
+                    }}
+                />
+            </a>
+
+            <div style={{ marginTop: 8, fontSize: 12, color: "#666" }}>
+                {commit.image.name}
+            </div>
+        </div>
+    )}
         <div style={{ marginTop: 12, fontSize: 12, color: "#888" }}>Commit ID: {commit.id}</div>
       </section>
     </main>

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -677,6 +677,14 @@ export default function TimerPage() {
                         endedAt: draftCommit.endedAt,
                         durationMs: draftCommit.endedAt - draftCommit.startedAt,
                         note: draftCommit.note,
+                        image: draftCommit.image
+                            ? {
+                                name: draftCommit.image.name,
+                                type: draftCommit.image.type,
+                                size: draftCommit.image.size,
+                                blob: draftCommit.image.file,
+                            }
+                            : null,
                     });
 
                     finalizeStopSession();
@@ -693,6 +701,14 @@ export default function TimerPage() {
                         endedAt: draftCommit.endedAt,
                         durationMs: draftCommit.endedAt - draftCommit.startedAt,
                         note: draftCommit.note,
+                        image: draftCommit.image
+                            ? {
+                                name: draftCommit.image.name,
+                                type: draftCommit.image.type,
+                                size: draftCommit.image.size,
+                                blob: draftCommit.image.file,
+                            }
+                            : null,
                     });
 
                     finalizeStopSession();

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -339,6 +339,7 @@ export default function TimerPage() {
             todayTotalMs,
             projectTotalMs,
             recentNotes,
+            image: null,
         };
 
         setDraftCommit(draft);


### PR DESCRIPTION
## 概要
コミットに画像を添付し保存・表示できる機能を実装しました。
![Animation](https://github.com/user-attachments/assets/638bb4f0-8ae9-4bf8-bb2a-acae89f37aef)

## 詳細
- Commimodalで画像を１枚選択できるように追加
- Canvasを用いて画像を圧縮（サイズ削減）
- IndexedDBにBlobとして保存
- CommitDetailPageで画像を表示

## 工夫した点
- 保存容量を抑えるため、画像を圧縮してから保存するようにした
- 表示用にはobjecturlを使用しBlobから直接描画出来るようにした
-  プレビュー表示と保存データを分離(File/Blob)して扱うことで、UIとデータ構造を整理

